### PR TITLE
Undefined api Key

### DIFF
--- a/seq_logger.js
+++ b/seq_logger.js
@@ -216,7 +216,7 @@ class SeqLogger {
             };
             
             if (this._apiKey) {
-                opts.headers["X-Seq-ApiKey"] = self._apiKey;
+                opts.headers["X-Seq-ApiKey"] = this._apiKey;
             }
 
             let req = http.request(opts);


### PR DESCRIPTION
We test for `this._apiKey` and then append `self._apiKey` where self is undefined.