### PR TITLE
Feature/beacon - add flushToBeacon()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Events are sent using the `emit()` method, that internally performs asynchronous
 
 When the application exits, `close()` ensures all buffered events are written. This can be done at any time otherwise using the `flush()` method. Both of these methods return promises indicating completion.
 
+When logging from a browser, and the application is being navigated away or closed, a `pagehide` or `unload` event listener has limited options and asynchronous methods will usually not succeed.  In that case, the application can call `flushToBeacon()` to queue all remaining buffered events into [`navigator.sendBeacon()`](https://developer.mozilla.org/docs/Web/API/Navigator/sendBeacon).  There is a size limit imposed by browsers so this is a best-effort attempt.
+
 ### Implementations
 
  * [bunyan-seq](https://github.com/continuousit/bunyan-seq) - collect events from the Buyan logging framework

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "simple-mock": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
+      "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
+      "dev": true
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "mocha": "^5.2.0",
+    "simple-mock": "^0.8.0",
     "superagent": "^3.8.3",
     "uuid": "^3.3.2"
   }

--- a/seq_logger.js
+++ b/seq_logger.js
@@ -67,8 +67,8 @@ class SeqLogger {
 
         const currentBatchSizeLimit = this._batchSizeLimit;
         const currentEventSizeLimit = this._eventSizeLimit;
-        this._batchSizeLimit = 63 * 1024;
-        this._eventSizeLimit = 63 * 1024;
+        this._batchSizeLimit = Math.min(63 * 1024, this._batchSizeLimit);
+        this._eventSizeLimit = Math.min(63 * 1024, this._eventSizeLimit);
 
         const dequeued = this._dequeBatch();
 

--- a/seq_logger.js
+++ b/seq_logger.js
@@ -51,6 +51,36 @@ class SeqLogger {
         return this._ship();
     }
 
+    // A browser only function that queues events for sending using the
+    // navigator.sendBeacon() API.  This may work in an unload or pagehide event
+    // handler when a normal flush() would not.
+    // Events over 63K in length are discarded (with a warning sent in its place) 
+    // and the total size batch will be no more than 63K in length.
+    flushToBeacon() {
+        if (this._queue.length === 0) {
+            return false;
+        }
+
+        if (typeof navigator === 'undefined' || !navigator.sendBeacon || typeof Blob === 'undefined') {
+            return false;
+        }
+
+        const currentBatchSizeLimit = this._batchSizeLimit;
+        const currentEventSizeLimit = this._eventSizeLimit;
+        this._batchSizeLimit = 63 * 1024;
+        this._eventSizeLimit = 63 * 1024;
+
+        const dequeued = this._dequeBatch();
+
+        this._batchSizeLimit = currentBatchSizeLimit;
+        this._eventSizeLimit = currentEventSizeLimit;
+
+        const {dataParts, options, beaconUrl, size} = this._prepForBeacon(dequeued);
+
+        const data = new Blob(dataParts, options);
+        return navigator.sendBeacon(beaconUrl, data);
+    }
+
     // Flush then close the logger, destroying timers and other resources.
     close() {
         if (this._closed) {
@@ -256,6 +286,24 @@ class SeqLogger {
             req.write(FOOTER);
             req.end();
         });
+    }
+
+    _prepForBeacon(dequeued) {        
+        const {batch, bytes} = dequeued;
+
+        const dataParts = [HEADER, batch.join(','), FOOTER];
+
+        // CORS-safelisted for the Content-Type request header
+        const options = {type: 'text/plain'};
+        
+        const endpointWithKey = Object.assign({}, this._endpoint, {query: {'apiKey': this._apiKey}});
+
+        return {
+            dataParts,
+            options,
+            beaconUrl: url.format(endpointWithKey),
+            size: bytes,
+        };
     }
 }
 


### PR DESCRIPTION
This is my proposed approach for #9 (Get final set of data for navigator.sendBeacon).

I used the method name `flushToBeacon()`.  I decided that the best approach is to actually make the `navigator.sendBeacon()` call if it exists.

An earlier version just returned the values of what is now `_prepForBeacon()` but it made more sense to do everything in the library.  For example, being able to return `false` if not sent for any reason, including required methods not existing.

