### PR TITLE
Update typescript Logger type to match the exported class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,7 @@ export interface SeqEvent {
   exception?: string;
 }
 
-export declare class SeqLogger {
+export declare class Logger {
   constructor(config: SeqLoggerConfig);
 
   emit(event: SeqEvent): void;


### PR DESCRIPTION
Hi All,

Thanks for creating Seq. I've noticed that the typescript types don't work quite right and that is due to the typescript .d.ts not matching the index.js export

https://github.com/datalust/seq-logging/blob/dev/index.js#L5 
```
module.exports = {Logger};
```


https://github.com/datalust/seq-logging/blob/dev/index.d.ts#L21
```
export declare class SeqLogger {
```


I've updated the .d.ts to match the export.