### PR TITLE
Improve screen reading of browser sample

### DIFF
--- a/example/browser/cypress/integration/log-event.spec.js
+++ b/example/browser/cypress/integration/log-event.spec.js
@@ -4,8 +4,6 @@ context('The app', () => {
     });
 
     it('logs to Seq', () => {
-        cy.get('#status').should('have.text', 'Use the button to log an event to Seq');
-
         cy.get('#log-event').click();
 
         cy.get('#status').should('have.text', 'Logging an event...');

--- a/example/browser/src/index.html
+++ b/example/browser/src/index.html
@@ -1,2 +1,2 @@
-<p id="status">Use the button to log an event to Seq</p>
 <button id="log-event" role="button">Log an event to Seq</button>
+<p id="status" role="alert" aria-live="assertive"></p>

--- a/example/browser/src/status.js
+++ b/example/browser/src/status.js
@@ -23,7 +23,7 @@ export default (message) => {
 
             if (next !== null) {
                 next();
-                update = null;
+                next = null;
             }
         }, 3000);
     }


### PR DESCRIPTION
Screen readers won't announce the status of our log event in flight unless we set an appropriate role and "noisiness" for the element. The button is self-descriptive so we don't need to just repeat its content in the status initially.