### PR TITLE
Attempt to avoid glitchy test hangs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "nyc --reporter=text mocha",
+    "test": "mocha",
+    "coverage": "nyc --reporter=text mocha",
     "start": "node ./example/example.js",
     "typecheck": "tsc --noEmit"
   },

--- a/test/seq_logger_tests.js
+++ b/test/seq_logger_tests.js
@@ -163,44 +163,50 @@ describe('SeqLogger', () => {
     describe("_post()", function () {
         it("retries 5 times after 5xx response from seq server", async () => {
             const mockSeq = new MockSeq();
-            const logger = new SeqLogger({ serverUrl: 'http://localhost:3000', maxBatchingTime: 1, retryDelay: 100 });
-            const event = makeTestEvent();
+            try {
+                const logger = new SeqLogger({ serverUrl: 'http://localhost:3000', maxBatchingTime: 1, retryDelay: 100 });
+                const event = makeTestEvent();
 
-            mockSeq.status = 500;
-            logger.emit(event);
-            await logger.flush();
-            assert.strictEqual(mockSeq.requestCount, 5);
-            await logger.close().then(() => {
+                mockSeq.status = 500;
+                logger.emit(event);
+                await logger.flush();
+                assert.strictEqual(mockSeq.requestCount, 5);
+                await logger.close();
+            } finally {
                 mockSeq.close();
-            });
+            }
         });
 
         it("does not retry on 4xx responses", async () => {
             const mockSeq = new MockSeq();
-            const logger = new SeqLogger({ serverUrl: 'http://localhost:3000', maxBatchingTime: 1, retryDelay: 100 });
-            const event = makeTestEvent();
+            try {
+                const logger = new SeqLogger({ serverUrl: 'http://localhost:3000', maxBatchingTime: 1, retryDelay: 100 });
+                const event = makeTestEvent();
 
-            mockSeq.status = 400;
-            logger.emit(event);
-            await logger.flush();
-            assert.strictEqual(mockSeq.requestCount, 1);
-            await logger.close().then(() => {
+                mockSeq.status = 400;
+                logger.emit(event);
+                await logger.flush();
+                assert.strictEqual(mockSeq.requestCount, 1);
+                await logger.close();
+            } finally {
                 mockSeq.close();
-            });
+            }
         });
 
         it("retries the amount of times set in configuration", async () => {
             const mockSeq = new MockSeq();
-            const logger = new SeqLogger({ serverUrl: 'http://localhost:3000', maxBatchingTime: 1, retryDelay: 100, maxRetries: 7 });
-            const event = makeTestEvent();
-
-            mockSeq.status = 503;
-            logger.emit(event);
-            await logger.flush();
-            assert.strictEqual(mockSeq.requestCount, 7);
-            await logger.close().then(() => {
+            try {
+                const logger = new SeqLogger({ serverUrl: 'http://localhost:3000', maxBatchingTime: 1, retryDelay: 100, maxRetries: 7 });
+                const event = makeTestEvent();
+    
+                mockSeq.status = 503;
+                logger.emit(event);
+                await logger.flush();
+                assert.strictEqual(mockSeq.requestCount, 7);
+                await logger.close()
+            } finally {
                 mockSeq.close();
-            });
+            }
         });
 
 


### PR DESCRIPTION
`npm run test` has been hanging sporadically for recent test runs; this it a first, straightforward attempt to figure out the cause.

 * Uses `mocha` directly for testing (no coverage by default)
 * Tears down the mock web server more reliably when used
 