### PR TITLE
Add required node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "start": "node ./example/example.js",
     "typecheck": "tsc --noEmit"
   },
+  "engines" : { 
+    "node" : ">=14.18"
+  },
   "author": "Datalust and contributors",
   "license": "Apache-2.0",
   "homepage": "https://github.com/datalust/seq-logging",


### PR DESCRIPTION
`seq-logging` does not work with < 14.18