### PR TITLE
Improve browser bundler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 > This library makes it easy to support Seq from Node.js logging libraries, including [Winston](https://github.com/winstonjs/winston) via [winston-seq](https://github.com/datalust/winston-seq), [Pino](https://github.com/pinojs/pino) via [`pino-seq`](https://github.com/datalust/pino-seq), [Bunyan](https://github.com/trentm/node-bunyan) via [`bunyan-seq`](https://github.com/continuousit/bunyan-seq), and [Ts.ED logger](https://logger.tsed.io) via [@tsed/logger-seq](https://logger.tsed.io/appenders/seq.html). It is not expected that applications will interact directly with this package.
 
+### Requiring for Node
+
+```js
+let seq = require('seq-logging');
+```
+
+### Requiring for a browser
+
+Using `seq-logging` in a browser context is the same, except the module to import is `seq-logging/browser`.
+
+```js
+let seq = require('seq-logging/browser');
+```
+
 ### Usage
 
 A `Logger` is configured with `serverUrl`, and optionally `apiKey` as well as event and batch size limits.

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,5 @@
+"use strict";
+
+let Logger = require('./seq_logger')(Blob, fetch);
+
+module.exports = {Logger};

--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,5 @@
 "use strict";
 
-let Logger = require('./seq_logger')(Blob, fetch);
+let Logger = require('./seq_logger')(Blob, fetch, typeof AbortController !== 'undefined' ? AbortController : require('abort-controller'));
 
 module.exports = {Logger};

--- a/example/browser/README.md
+++ b/example/browser/README.md
@@ -13,3 +13,9 @@ npm run serve
 ```
 
 and open a browser window to `localhost:8080` (or whatever port webpack uses). The script will connect to a Seq instance at `localhost:5341` and use the very fancy button to log an event. It will also listen for incoming events from the server and log them to the dev tools console.
+
+```
+npm run cypress
+```
+
+Runs the cypress tests. Fails if the Seq server has user authentication enabled. 

--- a/example/browser/package.json
+++ b/example/browser/package.json
@@ -9,7 +9,7 @@
     "test:html": "npm run build; npx concurrently --s first -k \"npm run serve\" \"npm run cypress\""
   },
   "dependencies": {
-    "seq-logging": "../../"
+    "seq-logging": "file:../../"
   },
   "devDependencies": {
     "@cypress/webpack-dev-server": "^1.3",

--- a/example/browser/src/log.js
+++ b/example/browser/src/log.js
@@ -2,7 +2,7 @@
 Create a logger that can write events to Seq.
 */
 
-import seq from 'seq-logging';
+import seq from 'seq-logging/web';
 import status from './status';
 
 export default (messageTemplate) => {

--- a/example/browser/src/log.js
+++ b/example/browser/src/log.js
@@ -2,7 +2,7 @@
 Create a logger that can write events to Seq.
 */
 
-import seq from 'seq-logging/web';
+import seq from 'seq-logging/browser';
 import status from './status';
 
 export default (messageTemplate) => {

--- a/example/example.js
+++ b/example/example.js
@@ -1,7 +1,7 @@
 "use strict";
 
 let process = require('process');
-let SeqLogger = require('../seq_logger');
+let SeqLogger = require('../index').Logger;
 
 let seq = new SeqLogger({ serverUrl: 'http://localhost:5341' });
 var n = 0;

--- a/example/example_async.js
+++ b/example/example_async.js
@@ -1,7 +1,7 @@
 "use strict";
 
 let process = require('process');
-let SeqLogger = require('../seq_logger');
+let SeqLogger = require('../index').Logger;
 
 let seq = new SeqLogger({ serverUrl: 'http://localhost:5341', onRemoteConfigChange: (config) => {
     console.log(config);

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,11 +43,4 @@ export declare class Logger {
    * @returns {Promise<boolean}
    */
   flush (): Promise<boolean>
-  /**
-   * * A browser only function that queues events for sending using the navigator.sendBeacon() API.
-   * * This may work in an unload or pagehide event handler when a normal flush() would not.
-   * * Events over 63K in length are discarded (with a warning sent in its place) and the total size batch will be no more than 63K in length.
-   * @returns {boolean}
-   */
-  flushToBeacon (): boolean
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 "use strict";
 
-let Logger = require('./seq_logger');
+let Logger = require('./seq_logger')(
+    typeof Blob !== 'undefined' ? Blob : require('buffer').Blob,
+    typeof fetch !== 'undefined' ? fetch : require('node-fetch')
+);
 
 module.exports = {Logger};

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
 let Logger = require('./seq_logger')(
     typeof Blob !== 'undefined' ? Blob : require('buffer').Blob,
-    typeof fetch !== 'undefined' ? fetch : require('node-fetch')
+    typeof fetch !== 'undefined' ? fetch : require('node-fetch'),
+    typeof AbortController !== 'undefined' ? AbortController : require('abort-controller')
 );
 
 module.exports = {Logger};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,27 @@
 {
   "name": "seq-logging",
-  "version": "1.2.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "seq-logging",
-      "version": "1.2.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.9"
       },
       "devDependencies": {
-        "mocha": "^9.2.2",
+        "mocha": "^10.2.0",
         "nyc": "^15.1.0",
         "simple-mock": "^0.8.0",
         "superagent": "^6.1.0",
         "typescript": "^4.7.4",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -347,12 +350,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -721,9 +718,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1081,15 +1078,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
-    },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.x"
-      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1664,54 +1652,60 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
       "dependencies": {
-        "@ungap/promise-all-settled": "1.1.2",
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+      "dev": true,
+      "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "bin": {
         "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
+        "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1722,29 +1716,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
@@ -1810,9 +1781,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -1908,15 +1879,6 @@
         "node": ">=8.9"
       }
     },
-    "node_modules/nyc/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nyc/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1974,15 +1936,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/nyc/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/nyc/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2002,32 +1955,6 @@
       "dev": true,
       "dependencies": {
         "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -2734,9 +2661,9 @@
       "dev": true
     },
     "node_modules/workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "node_modules/wrap-ansi": {
@@ -3204,12 +3131,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
-      "dev": true
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3503,9 +3424,9 @@
       }
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -3754,12 +3675,6 @@
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-      "dev": true
-    },
-    "growl": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has": {
@@ -4178,41 +4093,49 @@
       }
     },
     "minimatch": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.1.tgz",
-      "integrity": "sha512-9Uq1ChtSZO+Mxa/CL1eGizn2vRn3MlLgzhT0Iz8zaY8NdvxvB0d5QdPFmCKf7JKA9Lerx5vRrnwO03jsSfGG9g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
       }
     },
     "mocha": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
-      "integrity": "sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
-        "debug": "4.3.3",
+        "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.2.0",
-        "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "4.1.0",
         "log-symbols": "4.1.0",
-        "minimatch": "4.2.1",
+        "minimatch": "5.0.1",
         "ms": "2.1.3",
-        "nanoid": "3.3.1",
+        "nanoid": "3.3.3",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
-        "which": "2.0.2",
-        "workerpool": "6.2.0",
+        "workerpool": "6.2.1",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
@@ -4223,23 +4146,6 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -4290,9 +4196,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "node-fetch": {
@@ -4359,12 +4265,6 @@
         "yargs": "^15.0.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4410,12 +4310,6 @@
             "path-exists": "^4.0.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4432,26 +4326,6 @@
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
-          }
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
           }
         },
         "wrap-ansi": {
@@ -4989,9 +4863,9 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
-      "integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seq-logging",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Sends structured log events to the Seq HTTP ingestion API",
   "keywords": [
     "seq",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,6 @@
     "./index.d.ts",
     "./README.md",
     "./LICENSE"
-  ]
+  ],
+  "types": "./index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,13 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.9"
-  }
+  },
+  "files": [
+    "./index.js",
+    "./browser.js",
+    "./seq_logger.js",
+    "./index.d.ts",
+    "./README.md",
+    "./LICENSE"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seq-logging",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Sends structured log events to the Seq HTTP ingestion API",
   "keywords": [
     "seq",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "start": "node ./example/example.js",
     "typecheck": "tsc --noEmit"
   },
-  "engines" : { 
-    "node" : ">=14.18"
+  "engines": {
+    "node": ">=14.18"
   },
   "author": "Datalust and contributors",
   "license": "Apache-2.0",
@@ -24,7 +24,7 @@
     "url": "https://github.com/datalust/seq-logging.git"
   },
   "devDependencies": {
-    "mocha": "^9.2.2",
+    "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "simple-mock": "^0.8.0",
     "superagent": "^6.1.0",

--- a/seq_logger.js
+++ b/seq_logger.js
@@ -41,8 +41,6 @@ module.exports = function (safeGlobalBlob, safeGlobalFetch) {
             this._timer = null;
             this._closed = false;
             this._activeShipper = null;
-            this._onRemoteConfigChange = cfg.onRemoteConfigChange || null;
-            this._lastRemoteConfig = null;
         }
 
         /**

--- a/seq_logger.js
+++ b/seq_logger.js
@@ -1,7 +1,10 @@
 "use strict";
 
-const SafeGlobalBlob = typeof Blob !== 'undefined' ? Blob : require('buffer').Blob;
-const safeGlobalFetch = typeof fetch !== 'undefined' ? fetch : require('node-fetch');
+
+
+module.exports = function (SafeGlobalBlob, safeGlobalFetch) {
+//     const SafeGlobalBlob = typeof Blob !== 'undefined' ? Blob : require('buffer').Blob;
+// const safeGlobalFetch = typeof fetch !== 'undefined' ? fetch : require('node-fetch');
 const SafeGlobalAbortController = typeof AbortController !== 'undefined' ? AbortController : require('abort-controller');
 
 const HEADER = '{"Events":[';
@@ -289,8 +292,9 @@ class SeqLogger {
     }
 }
 
-module.exports = SeqLogger;
 
+    return SeqLogger;
+};
 
 const isValue = (obj) => {
     if (!obj) return true;

--- a/seq_logger.js
+++ b/seq_logger.js
@@ -1,296 +1,293 @@
 "use strict";
 
+module.exports = function (safeGlobalBlob, safeGlobalFetch) {
+    const safeGlobalAbortController = typeof AbortController !== 'undefined' ? AbortController : require('abort-controller');
 
+    const HEADER = '{"Events":[';
+    const FOOTER = "]}";
+    const HEADER_FOOTER_BYTES = (new safeGlobalBlob([HEADER])).size + (new safeGlobalBlob([FOOTER])).size;
 
-module.exports = function (SafeGlobalBlob, safeGlobalFetch) {
-//     const SafeGlobalBlob = typeof Blob !== 'undefined' ? Blob : require('buffer').Blob;
-// const safeGlobalFetch = typeof fetch !== 'undefined' ? fetch : require('node-fetch');
-const SafeGlobalAbortController = typeof AbortController !== 'undefined' ? AbortController : require('abort-controller');
-
-const HEADER = '{"Events":[';
-const FOOTER = "]}";
-const HEADER_FOOTER_BYTES = (new SafeGlobalBlob([HEADER])).size + (new SafeGlobalBlob([FOOTER])).size;
-
-class SeqLogger {
-    constructor(config) {
-        let dflt = {
-            serverUrl: 'http://localhost:5341',
-            apiKey: null,
-            maxBatchingTime: 2000,
-            eventSizeLimit: 256 * 1024,
-            batchSizeLimit: 1024 * 1024,
-            requestTimeout: 30000,
-            maxRetries: 5,
-            retryDelay: 5000,
-            onError: e => { console.error("[seq]", e); }
-        };
-        let cfg = config || dflt;
-        var serverUrl = cfg.serverUrl || dflt.serverUrl;
-        if (!serverUrl.endsWith('/')) {
-            serverUrl += '/';
-        }
-        this._endpoint = serverUrl + 'api/events/raw';
-        this._apiKey = cfg.apiKey || dflt.apiKey;
-        this._maxBatchingTime = cfg.maxBatchingTime || dflt.maxBatchingTime;
-        this._eventSizeLimit = cfg.eventSizeLimit || dflt.eventSizeLimit;
-        this._batchSizeLimit = cfg.batchSizeLimit || dflt.batchSizeLimit;
-        this._requestTimeout = cfg.requestTimeout || dflt.requestTimeout;
-        this._onError = cfg.onError || dflt.onError;
-        this._maxRetries = cfg.maxRetries || dflt.maxRetries;
-        this._retryDelay = cfg.retryDelay || dflt.retryDelay;
-
-        this._queue = [];
-        this._timer = null;
-        this._closed = false;
-        this._activeShipper = null;
-        this._onRemoteConfigChange = cfg.onRemoteConfigChange || null;
-        this._lastRemoteConfig = null;
-    }
-
-    /**
-     * Flush events queued at the time of the call, and wait for pending writes to complete regardless of configured batching/timers.
-     * @returns {Promise<boolean>}
-     */
-    flush () {
-        return this._ship();
-    }
-
-    /**
-     * Flush then destroy connections, close the logger, destroying timers and other resources.
-     * @returns {Promise<void>}
-     */
-    close () {
-        if (this._closed) {
-            throw new Error('The logger has already been closed.');
-        }
-
-        this._closed = true;
-        this._clearTimer();
-        return this.flush();
-    }
-
-    /**
-     * Enqueue an event in Seq format.
-     * @param {*} event 
-     * @returns {void}
-     */
-    emit (event) {
-        if (!event) {
-            throw new Error('An event must be provided');
-        }
-        if (this._closed) {
-            return;
-        }
-        let norm = this._toWireFormat(event);
-        this._queue.push(norm);
-        if (!this._activeShipper) {
-            this._setTimer();
-        }
-    }
-
-    _setTimer () {
-        if (this._timer !== null) {
-            return;
-        }
-
-        this._timer = setTimeout(() => {
-            this._timer = null;
-            this._onTimer();
-        }, this._maxBatchingTime);
-    }
-
-    _clearTimer () {
-        if (this._timer !== null) {
-            clearTimeout(this._timer);
-            this._timer = null;
-        }
-    }
-
-    _onTimer () {
-        if (!this._activeShipper) {
-            this._ship();
-        }
-    }
-
-    _toWireFormat (event) {
-        const level = typeof event.level === 'string' ? event.level : undefined;
-        const timestamp = event.timestamp instanceof Date ? event.timestamp : new Date();
-        const messageTemplate = typeof event.messageTemplate === 'string' ? event.messageTemplate :
-            event.messageTemplate !== null && event.messageTemplate !== undefined ? event.messageTemplate.toString() : "(No message provided)";
-        const exception = typeof event.exception === 'string' ? event.exception :
-            event.exception !== null && event.exception !== undefined ? event.exception.toString() : undefined;
-        const properties = typeof event.properties === 'object' ? event.properties : undefined;
-        return {
-            Timestamp: timestamp,
-            Level: level,
-            MessageTemplate: messageTemplate,
-            Exception: exception,
-            Properties: properties
-        };
-    }
-
-    _eventTooLargeErrorEvent (event) {
-        return {
-            Timestamp: event.Timestamp,
-            Level: event.Level,
-            MessageTemplate: "(Event too large) {initial}...",
-            Properties: {
-                initial: event.MessageTemplate.substring(0, 12),
-                sourceContext: "Seq Javascript Client",
-                eventSizeLimit: this._eventSizeLimit
+    class SeqLogger {
+        constructor(config) {
+            let dflt = {
+                serverUrl: 'http://localhost:5341',
+                apiKey: null,
+                maxBatchingTime: 2000,
+                eventSizeLimit: 256 * 1024,
+                batchSizeLimit: 1024 * 1024,
+                requestTimeout: 30000,
+                maxRetries: 5,
+                retryDelay: 5000,
+                onError: e => {
+                    console.error("[seq]", e);
+                }
+            };
+            let cfg = config || dflt;
+            var serverUrl = cfg.serverUrl || dflt.serverUrl;
+            if (!serverUrl.endsWith('/')) {
+                serverUrl += '/';
             }
-        };
-    }
+            this._endpoint = serverUrl + 'api/events/raw';
+            this._apiKey = cfg.apiKey || dflt.apiKey;
+            this._maxBatchingTime = cfg.maxBatchingTime || dflt.maxBatchingTime;
+            this._eventSizeLimit = cfg.eventSizeLimit || dflt.eventSizeLimit;
+            this._batchSizeLimit = cfg.batchSizeLimit || dflt.batchSizeLimit;
+            this._requestTimeout = cfg.requestTimeout || dflt.requestTimeout;
+            this._onError = cfg.onError || dflt.onError;
+            this._maxRetries = cfg.maxRetries || dflt.maxRetries;
+            this._retryDelay = cfg.retryDelay || dflt.retryDelay;
 
-    _reset (shipper) {
-        if (this._activeShipper === shipper) {
+            this._queue = [];
+            this._timer = null;
+            this._closed = false;
             this._activeShipper = null;
-            if (this._queue.length !== 0) {
+            this._onRemoteConfigChange = cfg.onRemoteConfigChange || null;
+            this._lastRemoteConfig = null;
+        }
+
+        /**
+         * Flush events queued at the time of the call, and wait for pending writes to complete regardless of configured batching/timers.
+         * @returns {Promise<boolean>}
+         */
+        flush() {
+            return this._ship();
+        }
+
+        /**
+         * Flush then destroy connections, close the logger, destroying timers and other resources.
+         * @returns {Promise<void>}
+         */
+        close() {
+            if (this._closed) {
+                throw new Error('The logger has already been closed.');
+            }
+
+            this._closed = true;
+            this._clearTimer();
+            return this.flush();
+        }
+
+        /**
+         * Enqueue an event in Seq format.
+         * @param {*} event
+         * @returns {void}
+         */
+        emit(event) {
+            if (!event) {
+                throw new Error('An event must be provided');
+            }
+            if (this._closed) {
+                return;
+            }
+            let norm = this._toWireFormat(event);
+            this._queue.push(norm);
+            if (!this._activeShipper) {
                 this._setTimer();
             }
         }
-    }
 
-    /**
-     * 
-     * @returns {Promise<boolean>}
-     */
-    _ship () {
-        if (this._queue.length === 0) {
-            return Promise.resolve(false);
+        _setTimer() {
+            if (this._timer !== null) {
+                return;
+            }
+
+            this._timer = setTimeout(() => {
+                this._timer = null;
+                this._onTimer();
+            }, this._maxBatchingTime);
         }
 
-        let wait = this._activeShipper || Promise.resolve(false);
-        let shipper = this._activeShipper = wait
-            .then(() => {
-                let more = drained => {
-                    if (drained) {
-                        // If the queue was drained, let the timer
-                        // push us forwards.
-                        return true;
-                    }
-                    return this._sendBatch().then(d => more(d));
+        _clearTimer() {
+            if (this._timer !== null) {
+                clearTimeout(this._timer);
+                this._timer = null;
+            }
+        }
+
+        _onTimer() {
+            if (!this._activeShipper) {
+                this._ship();
+            }
+        }
+
+        _toWireFormat(event) {
+            const level = typeof event.level === 'string' ? event.level : undefined;
+            const timestamp = event.timestamp instanceof Date ? event.timestamp : new Date();
+            const messageTemplate = typeof event.messageTemplate === 'string' ? event.messageTemplate :
+                event.messageTemplate !== null && event.messageTemplate !== undefined ? event.messageTemplate.toString() : "(No message provided)";
+            const exception = typeof event.exception === 'string' ? event.exception :
+                event.exception !== null && event.exception !== undefined ? event.exception.toString() : undefined;
+            const properties = typeof event.properties === 'object' ? event.properties : undefined;
+            return {
+                Timestamp: timestamp,
+                Level: level,
+                MessageTemplate: messageTemplate,
+                Exception: exception,
+                Properties: properties
+            };
+        }
+
+        _eventTooLargeErrorEvent(event) {
+            return {
+                Timestamp: event.Timestamp,
+                Level: event.Level,
+                MessageTemplate: "(Event too large) {initial}...",
+                Properties: {
+                    initial: event.MessageTemplate.substring(0, 12),
+                    sourceContext: "Seq Javascript Client",
+                    eventSizeLimit: this._eventSizeLimit
                 }
-                return this._sendBatch().then(drained => more(drained));
-            })
-            .then(() => this._reset(shipper), e => {
-                this._onError(e);
-                this._reset(shipper);
-            });
-
-        return shipper;
-    }
-
-    _sendBatch () {
-        if (this._queue.length === 0) {
-            return Promise.resolve(true);
+            };
         }
 
-        let dequeued = this._dequeBatch();
-        let drained = this._queue.length === 0;
-        return this._post(dequeued.batch, dequeued.bytes).then(() => drained);
-    }
-
-    _dequeBatch () {
-        var bytes = HEADER_FOOTER_BYTES;
-        let batch = [];
-        var i = 0;
-        var delimSize = 0;
-        while (i < this._queue.length) {
-            let next = this._queue[i];
-            let json;
-            try {
-                json = JSON.stringify(next);
+        _reset(shipper) {
+            if (this._activeShipper === shipper) {
+                this._activeShipper = null;
+                if (this._queue.length !== 0) {
+                    this._setTimer();
+                }
             }
-            catch (e) {
-                const cleaned = removeCirculars(next);
-                json = JSON.stringify(cleaned);
-                // Log that this event to be able to detect circular structures
-                // using same timestamp as cleaned event to make finding it easier
-                this.emit({
-                    timestamp: cleaned.Timestamp,
-                    level: "Error",
-                    messageTemplate: "[seq] Circular structure found"
-                });
-            }
-            var jsonLen = new SafeGlobalBlob([json]).size;
-            if (jsonLen > this._eventSizeLimit) {
-                this._onError("[seq] Event body is larger than " + this._eventSizeLimit + " bytes: " + json);
-                this._queue[i] = next = this._eventTooLargeErrorEvent(next);
-                json = JSON.stringify(next);
-                jsonLen = new SafeGlobalBlob([json]).size;
-            }
-
-            // Always try to send a batch of at least one event, even if the batch size is
-            // tiny.
-            if (i !== 0 && bytes + jsonLen + delimSize > this._batchSizeLimit) {
-                break;
-            }
-
-            i = i + 1;
-            bytes += jsonLen + delimSize;
-            delimSize = 1; // ","
-            batch.push(json);
         }
 
-        this._queue.splice(0, i);
-        return { batch, bytes };
-    }
+        /**
+         *
+         * @returns {Promise<boolean>}
+         */
+        _ship() {
+            if (this._queue.length === 0) {
+                return Promise.resolve(false);
+            }
 
-    _httpOrNetworkError (res) {
-        const networkErrors = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE', 'EAI_AGAIN', 'EBUSY'];
-        return networkErrors.includes(res) || 500 <= res.status && res.status < 600;
-    }
-
-    _post (batch, bytes) {
-        let attempts = 0;
-
-        return new Promise((resolve, reject) => {
-            const sendRequest = (batch, bytes) => {
-                const controller = new SafeGlobalAbortController();
-                attempts++;
-                const timerId = setTimeout(() => {
-                  controller.abort();
-                  if (attempts > this._maxRetries) {
-                    reject('HTTP log shipping failed, reached timeout (' + this._requestTimeout + ' ms)');           
-                  } else {
-                    setTimeout(() => sendRequest(batch, bytes), this._retryDelay);
-                  }
-                }, this._requestTimeout);
-
-                safeGlobalFetch(this._endpoint, {
-                  keepalive: true,
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                    "X-Seq-ApiKey": this._apiKey ? this._apiKey : null,
-                    "Content-Length": bytes,
-                  },
-                  body: `${HEADER}${batch.join(',')}${FOOTER}`,
-                  signal: controller.signal,
-                })
-                  .then((res) => {
-                    clearTimeout(timerId);
-                    let httpErr = null;
-                    if (res.status !== 200 && res.status !== 201) {
-                        httpErr = 'HTTP log shipping failed: ' + res.status;
-                        if (this._httpOrNetworkError(res) && attempts < this._maxRetries) {
-                            return setTimeout(() => sendRequest(batch, bytes), this._retryDelay);
+            let wait = this._activeShipper || Promise.resolve(false);
+            let shipper = this._activeShipper = wait
+                .then(() => {
+                    let more = drained => {
+                        if (drained) {
+                            // If the queue was drained, let the timer
+                            // push us forwards.
+                            return true;
                         }
-                        return reject(httpErr);
+                        return this._sendBatch().then(d => more(d));
                     }
-                    return resolve(true);
-                  })
-                  .catch((err) => {
-                    clearTimeout(timerId);
-                    reject(err);
-                  })
+                    return this._sendBatch().then(drained => more(drained));
+                })
+                .then(() => this._reset(shipper), e => {
+                    this._onError(e);
+                    this._reset(shipper);
+                });
+
+            return shipper;
+        }
+
+        _sendBatch() {
+            if (this._queue.length === 0) {
+                return Promise.resolve(true);
             }
 
-            return sendRequest(batch, bytes);
-        });
+            let dequeued = this._dequeBatch();
+            let drained = this._queue.length === 0;
+            return this._post(dequeued.batch, dequeued.bytes).then(() => drained);
+        }
+
+        _dequeBatch() {
+            var bytes = HEADER_FOOTER_BYTES;
+            let batch = [];
+            var i = 0;
+            var delimSize = 0;
+            while (i < this._queue.length) {
+                let next = this._queue[i];
+                let json;
+                try {
+                    json = JSON.stringify(next);
+                } catch (e) {
+                    const cleaned = removeCirculars(next);
+                    json = JSON.stringify(cleaned);
+                    // Log that this event to be able to detect circular structures
+                    // using same timestamp as cleaned event to make finding it easier
+                    this.emit({
+                        timestamp: cleaned.Timestamp,
+                        level: "Error",
+                        messageTemplate: "[seq] Circular structure found"
+                    });
+                }
+                var jsonLen = new safeGlobalBlob([json]).size;
+                if (jsonLen > this._eventSizeLimit) {
+                    this._onError("[seq] Event body is larger than " + this._eventSizeLimit + " bytes: " + json);
+                    this._queue[i] = next = this._eventTooLargeErrorEvent(next);
+                    json = JSON.stringify(next);
+                    jsonLen = new safeGlobalBlob([json]).size;
+                }
+
+                // Always try to send a batch of at least one event, even if the batch size is
+                // tiny.
+                if (i !== 0 && bytes + jsonLen + delimSize > this._batchSizeLimit) {
+                    break;
+                }
+
+                i = i + 1;
+                bytes += jsonLen + delimSize;
+                delimSize = 1; // ","
+                batch.push(json);
+            }
+
+            this._queue.splice(0, i);
+            return {batch, bytes};
+        }
+
+        _httpOrNetworkError(res) {
+            const networkErrors = ['ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE', 'EAI_AGAIN', 'EBUSY'];
+            return networkErrors.includes(res) || 500 <= res.status && res.status < 600;
+        }
+
+        _post(batch, bytes) {
+            let attempts = 0;
+
+            return new Promise((resolve, reject) => {
+                const sendRequest = (batch, bytes) => {
+                    const controller = new safeGlobalAbortController();
+                    attempts++;
+                    const timerId = setTimeout(() => {
+                        controller.abort();
+                        if (attempts > this._maxRetries) {
+                            reject('HTTP log shipping failed, reached timeout (' + this._requestTimeout + ' ms)');
+                        } else {
+                            setTimeout(() => sendRequest(batch, bytes), this._retryDelay);
+                        }
+                    }, this._requestTimeout);
+
+                    safeGlobalFetch(this._endpoint, {
+                        keepalive: true,
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            "X-Seq-ApiKey": this._apiKey ? this._apiKey : null,
+                            "Content-Length": bytes,
+                        },
+                        body: `${HEADER}${batch.join(',')}${FOOTER}`,
+                        signal: controller.signal,
+                    })
+                        .then((res) => {
+                            clearTimeout(timerId);
+                            let httpErr = null;
+                            if (res.status !== 200 && res.status !== 201) {
+                                httpErr = 'HTTP log shipping failed: ' + res.status;
+                                if (this._httpOrNetworkError(res) && attempts < this._maxRetries) {
+                                    return setTimeout(() => sendRequest(batch, bytes), this._retryDelay);
+                                }
+                                return reject(httpErr);
+                            }
+                            return resolve(true);
+                        })
+                        .catch((err) => {
+                            clearTimeout(timerId);
+                            reject(err);
+                        })
+                }
+
+                return sendRequest(batch, bytes);
+            });
+        }
     }
-}
 
 
     return SeqLogger;
@@ -308,8 +305,7 @@ const removeCirculars = (obj, branch = new Map(), path = "root") => {
         // In seq it is more clear if we remove the root.Properties object path
         const circularPath = branch.get(obj).replace("root.Properties.", "");
         return "== Circular structure: '" + circularPath + "' ==";
-    }
-    else {
+    } else {
         branch.set(obj, path);
     }
 

--- a/seq_logger.js
+++ b/seq_logger.js
@@ -1,8 +1,6 @@
 "use strict";
 
-module.exports = function (safeGlobalBlob, safeGlobalFetch) {
-    const safeGlobalAbortController = typeof AbortController !== 'undefined' ? AbortController : require('abort-controller');
-
+module.exports = function (safeGlobalBlob, safeGlobalFetch, safeGlobalAbortController) {
     const HEADER = '{"Events":[';
     const FOOTER = "]}";
     const HEADER_FOOTER_BYTES = (new safeGlobalBlob([HEADER])).size + (new safeGlobalBlob([FOOTER])).size;

--- a/test/seq_logger_integration_tests.js
+++ b/test/seq_logger_integration_tests.js
@@ -3,7 +3,7 @@
 let assert = require('assert');
 let uuid = require('uuid');
 let request = require('superagent');
-let SeqLogger = require('../seq_logger');
+let SeqLogger = require('../index').Logger;
 
 // TEST CONFIGURATION
 const serverUrlHttp = '[CONFIGURE_URL_HERE]';

--- a/test/seq_logger_tests.js
+++ b/test/seq_logger_tests.js
@@ -2,7 +2,7 @@
 
 let assert = require('assert');
 const http = require("http");
-let SeqLogger = require('../seq_logger');
+let SeqLogger = require('../index').Logger;
 
 describe('SeqLogger', () => {
     


### PR DESCRIPTION
`seq-logging` currently requires some client configuration (polyfills) for scenarios targeting the browser and using a bundler, like webpack or rollup. 

This PR introduces a second entry for the library, `seq-logging/web` that avoids importing node.js modules that cause a problem with bundlers. 

https://github.com/datalust/seq-logging/issues/61